### PR TITLE
Add CI/CD workflow and document key exports

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,25 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run bot
+        env:
+          BINANCE_API_KEY: ${{ secrets.BINANCE_API_KEY }}
+          BINANCE_SECRET_KEY: ${{ secrets.BINANCE_SECRET_KEY }}
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          DRY_RUN: ${{ secrets.DRY_RUN }}
+        run: python arb_eur_bot_class.py

--- a/README.md
+++ b/README.md
@@ -9,9 +9,19 @@ Ce dépôt contient un bot d'arbitrage triangulaire pour Binance.
    pip install -r requirements.txt
    ```
 2. Définir les variables d'environnement nécessaires :
-   - `BINANCE_API_KEY` et `BINANCE_SECRET_KEY` pour l'accès à l'API Binance.
-   - Facultatif : `TELEGRAM_TOKEN` et `TELEGRAM_CHAT_ID` pour recevoir des alertes Telegram.
-   - `DRY_RUN=0` pour exécuter réellement les transactions (par défaut `DRY_RUN=1` simule seulement).
+
+   Exporter les clés dans votre terminal avant de lancer le bot :
+
+   ```bash
+   export BINANCE_API_KEY="votre_cle"
+   export BINANCE_SECRET_KEY="votre_secret"
+   # Facultatif :
+   export TELEGRAM_TOKEN="votre_token"
+   export TELEGRAM_CHAT_ID="votre_chat_id"
+   export DRY_RUN=1  # passer à 0 pour exécuter réellement les transactions
+   ```
+
+   Dans GitHub Actions, ajoutez ces mêmes variables comme secrets via **Settings > Secrets and variables > Actions** pour permettre au workflow de déployer le bot.
 3. Lancer le bot :
    ```bash
    python arb_eur_bot_class.py


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy the bot on pushes to main
- document how to export API keys and set secrets for the workflow

## Testing
- `python -m py_compile arb_eur_bot_class.py`


------
https://chatgpt.com/codex/tasks/task_e_68af413e25c88326ae4442847ce0c885